### PR TITLE
Add gatsby v3 support in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "valine": "^1.4.14"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
This module run well with Gatsby v3, but always throw warn when building, so I add gatsby v3 support in peer dependencies.